### PR TITLE
return sendable futures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,9 +67,9 @@ pub use error::Error;
 /// `path_prefix` is assumed to be the path prefixed, e.g `/sweet-app/prod`.
 /// Parameter store value names are then expected be of the form `/sweet-app/prod/db-pass`
 /// `/sweet-app/prod/db-username`, and so forth.
-pub fn from_path<T, P>(path_prefix: P) -> impl Future<Item = T, Error = Error>
+pub fn from_path<T, P>(path_prefix: P) -> impl Future<Item = T, Error = Error> + Send
 where
-    T: DeserializeOwned,
+    T: DeserializeOwned + Send,
     P: AsRef<Path>,
 {
     ::from_client(SsmClient::new(Default::default()), path_prefix)
@@ -82,10 +82,10 @@ where
 pub fn from_client<T, C, P>(
     client: C,
     path_prefix: P,
-) -> impl Future<Item = T, Error = Error>
+) -> impl Future<Item = T, Error = Error> + Send
 where
-    T: DeserializeOwned,
-    C: Ssm,
+    T: DeserializeOwned + Send,
+    C: Ssm + Send,
     P: AsRef<Path>,
 {
     enum PageState {


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo  +nightly fmt` before submitting a pr.
-->

## What did you implement:

it's often the case that the type for futures also require `Send` to indicate that they are safe for sending across thread barriers. Let's satisfy that

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

#### What (if anything) would need to be called out in the CHANGELOG for the next release: